### PR TITLE
Update winit from 0.23.0 to 0.24.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ keywords = ["winit", "input", "helper", "state", "cache"]
 categories = ["game-engines", "os", "gui"]
 
 [dependencies]
-winit = "0.23.0"
+winit = "0.24.0"


### PR DESCRIPTION
Hi there :) 


No code change is necessary (as far as I can tell!). The only two points from the [changelog](https://github.com/rust-windowing/winit/blob/master/CHANGELOG.md#0240-2020-12-09) that are relevant (related to input):

- "Breaking: On Windows, include prefix byte in scancodes."
  => This crate doesn't use scancodes directly
- "Breaking Rename desktop::EventLoopExtDesktop to run_return::EventLoopExtRunReturn."
  => This crate doesn't use `EventLoopExtDesktop`
- "Breaking: MouseButton::Other now uses u16."
  => This crate uses `MouseButton::Other` but immediately casts the value
     to `usize`, so everything still works as expected.