### PR TITLE
Split `mouse_diff` into `cursor_diff` and `mouse_diff`

### DIFF
--- a/examples/example.rs
+++ b/examples/example.rs
@@ -27,12 +27,16 @@ fn main() {
                 return;
             }
 
-            // query the change in mouse this update
-            let mouse_diff = input.mouse_diff();
-            if mouse_diff != (0.0, 0.0) {
-                println!("The mouse diff is: {:?}", mouse_diff);
-                println!("The mouse position is: {:?}", input.mouse());
+            // query the change in cursor this update
+            let cursor_diff = input.cursor_diff();
+            if cursor_diff != (0.0, 0.0) {
+                println!("The cursor diff is: {:?}", cursor_diff);
+                println!("The cursor position is: {:?}", input.cursor());
             }
+
+            //query the change in mouse this update (useful for camera)
+            let mouse_diff = input.mouse_diff();
+            println!("The mouse diff is: {:?}", mouse_diff);
 
             // You are expected to control your own timing within this block.
             // Usually via rendering with vsync.

--- a/src/current_input.rs
+++ b/src/current_input.rs
@@ -1,4 +1,4 @@
-use winit::event::{ElementState, MouseButton, MouseScrollDelta, VirtualKeyCode, WindowEvent};
+use winit::event::{ElementState, MouseButton, MouseScrollDelta, VirtualKeyCode, WindowEvent, DeviceEvent};
 
 /// Stores a character or a backspace.
 ///
@@ -18,8 +18,9 @@ pub struct CurrentInput {
     pub key_actions: Vec<KeyAction>,
     pub key_held: [bool; 255],
     pub mouse_held: [bool; 255],
-    pub mouse_point: Option<(f32, f32)>,
-    pub mouse_point_prev: Option<(f32, f32)>,
+    pub cursor_point: Option<(f32, f32)>,
+    pub cursor_point_prev: Option<(f32, f32)>,
+    pub mouse_diff: Option<(f32, f32)>,
     pub scroll_diff: f32,
     pub text: Vec<TextChar>,
 }
@@ -31,8 +32,9 @@ impl CurrentInput {
             key_actions: vec![],
             key_held: [false; 255],
             mouse_held: [false; 255],
-            mouse_point: None,
-            mouse_point_prev: None,
+            cursor_point: None,
+            cursor_point_prev: None,
+            mouse_diff: None,
             scroll_diff: 0.0,
             text: vec![],
         }
@@ -42,7 +44,8 @@ impl CurrentInput {
         self.mouse_actions.clear();
         self.key_actions.clear();
         self.scroll_diff = 0.0;
-        self.mouse_point_prev = self.mouse_point;
+        self.cursor_point_prev = self.cursor_point;
+        self.mouse_diff = None;
         self.text.clear();
     }
 
@@ -75,7 +78,7 @@ impl CurrentInput {
                 }
             }
             WindowEvent::CursorMoved { position, .. } => {
-                self.mouse_point = Some((position.x as f32, position.y as f32));
+                self.cursor_point = Some((position.x as f32, position.y as f32));
             }
             WindowEvent::MouseInput {
                 state: ElementState::Pressed,
@@ -108,6 +111,15 @@ impl CurrentInput {
                     }
                 }
             }
+            _ => {}
+        }
+    }
+    
+    pub fn handle_device_event(&mut self, event: &DeviceEvent ) {
+        match event {
+            DeviceEvent::MouseMotion {delta, ..} => {
+                self.mouse_diff = Some( (delta.0 as f32, delta.1 as f32) )
+            },
             _ => {}
         }
     }

--- a/src/current_input.rs
+++ b/src/current_input.rs
@@ -1,4 +1,6 @@
-use winit::event::{ElementState, MouseButton, MouseScrollDelta, VirtualKeyCode, WindowEvent, DeviceEvent};
+use winit::event::{
+    DeviceEvent, ElementState, MouseButton, MouseScrollDelta, VirtualKeyCode, WindowEvent,
+};
 
 /// Stores a character or a backspace.
 ///
@@ -114,12 +116,12 @@ impl CurrentInput {
             _ => {}
         }
     }
-    
-    pub fn handle_device_event(&mut self, event: &DeviceEvent ) {
+
+    pub fn handle_device_event(&mut self, event: &DeviceEvent) {
         match event {
-            DeviceEvent::MouseMotion {delta, ..} => {
-                self.mouse_diff = Some( (delta.0 as f32, delta.1 as f32) )
-            },
+            DeviceEvent::MouseMotion { delta, .. } => {
+                self.mouse_diff = Some((delta.0 as f32, delta.1 as f32))
+            }
             _ => {}
         }
     }

--- a/src/winit_input_helper.rs
+++ b/src/winit_input_helper.rs
@@ -1,5 +1,5 @@
 use winit::dpi::PhysicalSize;
-use winit::event::{Event, VirtualKeyCode, WindowEvent, DeviceEvent};
+use winit::event::{DeviceEvent, Event, VirtualKeyCode, WindowEvent};
 
 use crate::current_input::{CurrentInput, KeyAction, MouseAction, TextChar};
 use std::path::PathBuf;
@@ -67,7 +67,7 @@ impl WinitInputHelper {
             Event::DeviceEvent { event, .. } => {
                 self.process_device_event(event);
                 false
-            },
+            }
             Event::MainEventsCleared => true,
             _ => false,
         }
@@ -121,7 +121,7 @@ impl WinitInputHelper {
             current.handle_event(event);
         }
     }
-    
+
     fn process_device_event(&mut self, event: &DeviceEvent) {
         if let Some(ref mut current) = self.current {
             current.handle_device_event(event);


### PR DESCRIPTION
Implementaion of changes in #12.
This one shouldn't be auto formatted and shouldn't create much merge conflicts.
Also I changed the example as a seperate commit and tried to provide readable documentation.