### PR TITLE
Support for scan codes

### DIFF
--- a/examples/example.rs
+++ b/examples/example.rs
@@ -28,6 +28,21 @@ fn main() {
                 return;
             }
 
+            if input.key_pressed_scancode(17) {
+                // 17 is W for QWERTY
+                println!("The 'W' key was pressed on the keyboard (scan code)");
+            }
+
+            if input.key_pressed_os_scancode(18) {
+                // 18 is E for QWERTY
+                println!("The 'E' key was pressed on the keyboard (scan code, Os Repeating)");
+            }
+
+            if input.key_held_scancode(19) {
+                // 19 is R for QWERTY
+                println!("The 'R' key is held (scan code)");
+            }
+
             // query the change in mouse this update
             let mouse_diff = input.mouse_diff();
             if mouse_diff != (0.0, 0.0) {

--- a/src/current_input.rs
+++ b/src/current_input.rs
@@ -1,4 +1,6 @@
-use winit::event::{ElementState, MouseButton, MouseScrollDelta, VirtualKeyCode, WindowEvent};
+use winit::event::{
+    ElementState, MouseButton, MouseScrollDelta, ScanCode, VirtualKeyCode, WindowEvent,
+};
 
 /// Stores a character or a backspace.
 ///
@@ -16,7 +18,9 @@ pub enum TextChar {
 pub struct CurrentInput {
     pub mouse_actions: Vec<MouseAction>,
     pub key_actions: Vec<KeyAction>,
+    pub scancode_actions: Vec<ScanCodeAction>,
     pub key_held: [bool; 255],
+    pub scancode_held: Vec<ScanCode>, // some scan codes are higher than 255 so using an array may be dangerous
     pub mouse_held: [bool; 255],
     pub mouse_point: Option<(f32, f32)>,
     pub mouse_point_prev: Option<(f32, f32)>,
@@ -30,7 +34,9 @@ impl CurrentInput {
         CurrentInput {
             mouse_actions: vec![],
             key_actions: vec![],
+            scancode_actions: vec![],
             key_held: [false; 255],
+            scancode_held: vec![],
             mouse_held: [false; 255],
             mouse_point: None,
             mouse_point_prev: None,
@@ -43,6 +49,7 @@ impl CurrentInput {
     pub fn step(&mut self) {
         self.mouse_actions.clear();
         self.key_actions.clear();
+        self.scancode_actions.clear();
         self.y_scroll_diff = 0.0;
         self.x_scroll_diff = 0.0;
         self.mouse_point_prev = self.mouse_point;
@@ -52,22 +59,42 @@ impl CurrentInput {
     pub fn handle_event(&mut self, event: &WindowEvent) {
         match event {
             WindowEvent::KeyboardInput { input, .. } => {
-                if let Some(keycode) = input.virtual_keycode {
-                    match input.state {
-                        ElementState::Pressed => {
+                match input.state {
+                    ElementState::Pressed => {
+                        if let Some(keycode) = input.virtual_keycode {
                             if !self.key_held[keycode as usize] {
                                 self.key_actions.push(KeyAction::Pressed(keycode));
                             }
+
                             self.key_held[keycode as usize] = true;
                             self.key_actions.push(KeyAction::PressedOs(keycode));
                             if let VirtualKeyCode::Back = keycode {
                                 self.text.push(TextChar::Back);
                             }
                         }
-                        ElementState::Released => {
+
+                        let scancode = input.scancode;
+
+                        if !self.scancode_held.contains(&scancode) {
+                            self.scancode_actions
+                                .push(ScanCodeAction::Pressed(scancode));
+                            self.scancode_held.push(scancode);
+                        }
+
+                        self.scancode_actions
+                            .push(ScanCodeAction::PressedOs(scancode));
+                        // no handling for the back key as a scancode
+                    }
+                    ElementState::Released => {
+                        if let Some(keycode) = input.virtual_keycode {
                             self.key_held[keycode as usize] = false;
                             self.key_actions.push(KeyAction::Released(keycode));
                         }
+
+                        let scancode = input.scancode;
+                        self.scancode_held.retain(|&x| x != scancode);
+                        self.scancode_actions
+                            .push(ScanCodeAction::Released(scancode));
                     }
                 }
             }
@@ -123,6 +150,13 @@ pub enum KeyAction {
     Pressed(VirtualKeyCode),
     PressedOs(VirtualKeyCode),
     Released(VirtualKeyCode),
+}
+
+#[derive(Clone, PartialEq)]
+pub enum ScanCodeAction {
+    Pressed(ScanCode),
+    PressedOs(ScanCode),
+    Released(ScanCode),
 }
 
 #[derive(Clone)]

--- a/src/current_input.rs
+++ b/src/current_input.rs
@@ -58,46 +58,43 @@ impl CurrentInput {
 
     pub fn handle_event(&mut self, event: &WindowEvent) {
         match event {
-            WindowEvent::KeyboardInput { input, .. } => {
-                match input.state {
-                    ElementState::Pressed => {
-                        if let Some(keycode) = input.virtual_keycode {
-                            if !self.key_held[keycode as usize] {
-                                self.key_actions.push(KeyAction::Pressed(keycode));
-                            }
-
-                            self.key_held[keycode as usize] = true;
-                            self.key_actions.push(KeyAction::PressedOs(keycode));
-                            if let VirtualKeyCode::Back = keycode {
-                                self.text.push(TextChar::Back);
-                            }
+            WindowEvent::KeyboardInput { input, .. } => match input.state {
+                ElementState::Pressed => {
+                    if let Some(keycode) = input.virtual_keycode {
+                        if !self.key_held[keycode as usize] {
+                            self.key_actions.push(KeyAction::Pressed(keycode));
                         }
 
-                        let scancode = input.scancode;
-
-                        if !self.scancode_held.contains(&scancode) {
-                            self.scancode_actions
-                                .push(ScanCodeAction::Pressed(scancode));
-                            self.scancode_held.push(scancode);
+                        self.key_held[keycode as usize] = true;
+                        self.key_actions.push(KeyAction::PressedOs(keycode));
+                        if let VirtualKeyCode::Back = keycode {
+                            self.text.push(TextChar::Back);
                         }
-
-                        self.scancode_actions
-                            .push(ScanCodeAction::PressedOs(scancode));
-                        // no handling for the back key as a scancode
                     }
-                    ElementState::Released => {
-                        if let Some(keycode) = input.virtual_keycode {
-                            self.key_held[keycode as usize] = false;
-                            self.key_actions.push(KeyAction::Released(keycode));
-                        }
 
-                        let scancode = input.scancode;
-                        self.scancode_held.retain(|&x| x != scancode);
+                    let scancode = input.scancode;
+
+                    if !self.scancode_held.contains(&scancode) {
                         self.scancode_actions
-                            .push(ScanCodeAction::Released(scancode));
+                            .push(ScanCodeAction::Pressed(scancode));
+                        self.scancode_held.push(scancode);
                     }
+
+                    self.scancode_actions
+                        .push(ScanCodeAction::PressedOs(scancode));
                 }
-            }
+                ElementState::Released => {
+                    if let Some(keycode) = input.virtual_keycode {
+                        self.key_held[keycode as usize] = false;
+                        self.key_actions.push(KeyAction::Released(keycode));
+                    }
+
+                    let scancode = input.scancode;
+                    self.scancode_held.retain(|&x| x != scancode);
+                    self.scancode_actions
+                        .push(ScanCodeAction::Released(scancode));
+                }
+            },
             WindowEvent::ReceivedCharacter(c) => {
                 let c = *c;
                 if c != '\x08' && c != '\r' && c != '\n' {

--- a/src/winit_input_helper.rs
+++ b/src/winit_input_helper.rs
@@ -183,7 +183,7 @@ impl WinitInputHelper {
     /// Returns true when the key with the specified scancode goes from "not pressed" to "pressed".
     /// Otherwise returns false.
     ///
-    /// This is suitable for game controls that do not depend on the user  keyboard layout.
+    /// This is suitable for game controls that do not depend on the user keyboard layout.
     pub fn key_pressed_scancode(&self, scancode: ScanCode) -> bool {
         if let Some(current) = &self.current {
             let searched_action = ScanCodeAction::Pressed(scancode);
@@ -211,7 +211,7 @@ impl WinitInputHelper {
 
     /// Returns true when the key with the specified scancode goes from "pressed" to "not pressed".
     /// Otherwise returns false.
-    /// 
+    ///
     /// This does not depend on the user keyboard layout.
     pub fn key_released_scancode(&self, scancode: ScanCode) -> bool {
         if let Some(current) = &self.current {
@@ -225,7 +225,7 @@ impl WinitInputHelper {
 
     /// Returns true when the key with the specified scancode remains "pressed".
     /// Otherwise returns false.
-    /// 
+    ///
     /// This does not depend on the user keyboard layout.
     pub fn key_held_scancode(&self, scancode: ScanCode) -> bool {
         if let Some(current) = &self.current {

--- a/src/winit_input_helper.rs
+++ b/src/winit_input_helper.rs
@@ -1,7 +1,7 @@
 use winit::dpi::PhysicalSize;
-use winit::event::{Event, VirtualKeyCode, WindowEvent};
+use winit::event::{Event, ScanCode, VirtualKeyCode, WindowEvent};
 
-use crate::current_input::{CurrentInput, KeyAction, MouseAction, TextChar};
+use crate::current_input::{CurrentInput, KeyAction, MouseAction, ScanCodeAction, TextChar};
 use std::path::PathBuf;
 
 /// The main struct of the API.
@@ -178,6 +178,60 @@ impl WinitInputHelper {
             Some(current) => current.key_held[key_code as usize],
             None => false,
         }
+    }
+
+    /// Returns true when the key with the specified scancode goes from "not pressed" to "pressed".
+    /// Otherwise returns false.
+    ///
+    /// This is suitable for game controls that do not depend on the user  keyboard layout.
+    pub fn key_pressed_scancode(&self, scancode: ScanCode) -> bool {
+        if let Some(current) = &self.current {
+            let searched_action = ScanCodeAction::Pressed(scancode);
+            if current.scancode_actions.contains(&searched_action) {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Returns true when the key with the specified scancode goes from "not pressed" to "pressed".
+    /// Otherwise returns false.
+    ///
+    /// Will repeat key presses while held down according to the OS's key repeat configuration
+    /// This is suitable for UI, and does not depend on the user keyboard layout.
+    pub fn key_pressed_os_scancode(&self, scancode: ScanCode) -> bool {
+        if let Some(current) = &self.current {
+            let searched_action = ScanCodeAction::PressedOs(scancode);
+            if current.scancode_actions.contains(&searched_action) {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Returns true when the key with the specified scancode goes from "pressed" to "not pressed".
+    /// Otherwise returns false.
+    /// 
+    /// This does not depend on the user keyboard layout.
+    pub fn key_released_scancode(&self, scancode: ScanCode) -> bool {
+        if let Some(current) = &self.current {
+            let searched_action = ScanCodeAction::Released(scancode);
+            if current.scancode_actions.contains(&searched_action) {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Returns true when the key with the specified scancode remains "pressed".
+    /// Otherwise returns false.
+    /// 
+    /// This does not depend on the user keyboard layout.
+    pub fn key_held_scancode(&self, scancode: ScanCode) -> bool {
+        if let Some(current) = &self.current {
+            return current.scancode_held.contains(&scancode);
+        }
+        false
     }
 
     /// Returns true while any shift key is held on the keyboard.


### PR DESCRIPTION
This PR implements issue #33. 

I added 4 new functions : 
- `key_pressed_scancode`
- `key_pressed_os_scancode`
- `key_released_scancode`
- `key_held_scancode`

And modified the example accordingly.

The code is very similar to what was already done with VirtualKeyCodes, except for the held part. Some scan codes (at least on my keyboard) are higher than 255, so using an array was not practical. Instead I used a Vec, checking if it already contains the specified key when needed. 