### PR TITLE
Fix cursor docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1349,7 +1349,7 @@ dependencies = [
 
 [[package]]
 name = "winit_input_helper"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "winit",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "winit_input_helper"
 repository = "https://github.com/rukai/winit_input_helper"
-version = "0.15.0"
+version = "0.15.1"
 edition = "2021"
 authors = ["Rukai <rubickent@gmail.com>"]
 license = "MIT"

--- a/src/winit_input_helper.rs
+++ b/src/winit_input_helper.rs
@@ -342,7 +342,7 @@ impl WinitInputHelper {
         }
     }
 
-    /// Returns `(0.0, 0.0)` if the mouse is outside of the window.
+    /// Returns `(0.0, 0.0)` when the window is not focused.
     /// Otherwise returns the amount scrolled by the mouse during the last step.
     /// Returns (horizontally, vertically)
     pub fn scroll_diff(&self) -> (f32, f32) {
@@ -352,7 +352,7 @@ impl WinitInputHelper {
         }
     }
 
-    /// Returns `None` when the cursor is outside of the window.
+    /// Returns `None` when the window is not focused.
     /// Otherwise returns the cursor coordinates in pixels.
     pub fn cursor(&self) -> Option<(f32, f32)> {
         match &self.current {

--- a/src/winit_input_helper.rs
+++ b/src/winit_input_helper.rs
@@ -352,8 +352,8 @@ impl WinitInputHelper {
         }
     }
 
-    /// Returns `None` when the window is not focused.
-    /// Otherwise returns the cursor coordinates in pixels.
+    /// Returns the cursor coordinates in pixels, when window is focused AND (cursor is on window OR any mouse button remains held while cursor moved off window) 
+    /// Otherwise returns `None`
     pub fn cursor(&self) -> Option<(f32, f32)> {
         match &self.current {
             Some(current) => current.cursor_point,
@@ -361,8 +361,8 @@ impl WinitInputHelper {
         }
     }
 
-    /// Returns the change in cursor coordinates that occured during the last step.
-    /// Returns `(0.0, 0.0)` if the window loses focus.
+    /// Returns the change in cursor coordinates that occured during the last step, when window is focused AND (cursor is on window OR any mouse button remains held while cursor moved off window) 
+    /// Otherwise returns `(0.0, 0.0)`.
     pub fn cursor_diff(&self) -> (f32, f32) {
         if let Some(current_input) = &self.current {
             if let Some(cur) = current_input.cursor_point {

--- a/src/winit_input_helper.rs
+++ b/src/winit_input_helper.rs
@@ -352,7 +352,7 @@ impl WinitInputHelper {
         }
     }
 
-    /// Returns the cursor coordinates in pixels, when window is focused AND (cursor is on window OR any mouse button remains held while cursor moved off window) 
+    /// Returns the cursor coordinates in pixels, when window is focused AND (cursor is on window OR any mouse button remains held while cursor moved off window)
     /// Otherwise returns `None`
     pub fn cursor(&self) -> Option<(f32, f32)> {
         match &self.current {
@@ -361,7 +361,7 @@ impl WinitInputHelper {
         }
     }
 
-    /// Returns the change in cursor coordinates that occured during the last step, when window is focused AND (cursor is on window OR any mouse button remains held while cursor moved off window) 
+    /// Returns the change in cursor coordinates that occured during the last step, when window is focused AND (cursor is on window OR any mouse button remains held while cursor moved off window)
     /// Otherwise returns `(0.0, 0.0)`.
     pub fn cursor_diff(&self) -> (f32, f32) {
         if let Some(current_input) = &self.current {


### PR DESCRIPTION
closes https://github.com/rukai/winit_input_helper/issues/36

The documentation was just wrong.
This PR fixes the documentation.
I've verified this behavior on both windows and x11/i3