### PR TITLE
Track step duration and provide delta_time

### DIFF
--- a/src/winit_input_helper.rs
+++ b/src/winit_input_helper.rs
@@ -107,6 +107,7 @@ impl WinitInputHelper {
         self.window_resized = None;
         self.scale_factor_changed = None;
         self.close_requested = false;
+        // Set the start time on the first event to avoid the first step appearing too long
         self.step_start.get_or_insert(Instant::now());
         self.step_duration = None;
         if let Some(current) = &mut self.current {

--- a/src/winit_input_helper.rs
+++ b/src/winit_input_helper.rs
@@ -3,7 +3,10 @@ use winit::event::{DeviceEvent, Event, WindowEvent};
 use winit::keyboard::{Key, KeyCode, PhysicalKey};
 
 use crate::current_input::{CurrentInput, KeyAction, MouseAction, ScanCodeAction, TextChar};
-use std::{path::PathBuf, time::{Instant, Duration}};
+use std::{
+    path::PathBuf,
+    time::{Duration, Instant},
+};
 
 /// The main struct of the API.
 ///
@@ -50,7 +53,7 @@ impl WinitInputHelper {
             destroyed: false,
             close_requested: false,
             step_start: None,
-            step_duration : None,
+            step_duration: None,
         }
     }
 
@@ -78,7 +81,7 @@ impl WinitInputHelper {
             Event::AboutToWait => {
                 self.end_step();
                 true
-            },
+            }
             _ => false,
         }
     }


### PR DESCRIPTION
At the end of each step: save the duration since the last step and the start time for the next step.
Useful for adapting gradual changes to be independent of frame rate: 
```rust
x += x_per_second * input.delta_time().unwrap().as_secs_f32();
```

https://github.com/rukai/winit_input_helper/assets/39150378/e3487954-efd7-4b54-b882-92365b7ba22c

