### PR TITLE
Use MouseButton enum in mouse-related methods signatures

### DIFF
--- a/examples/example.rs
+++ b/examples/example.rs
@@ -1,6 +1,7 @@
 //! A complex example demonstrating use of every API feature, runs on both desktop and web.
 //! To run on desktop: `cargo run --example example`
 //! To run on web: `cargo run-wasm --example example`
+use winit::event::MouseButton;
 use winit::event_loop::EventLoop;
 use winit::keyboard::{Key, KeyCode};
 use winit_input_helper::WinitInputHelper;
@@ -77,6 +78,22 @@ fn main() {
                 if scroll_diff != (0.0, 0.0) {
                     log::info!("The scroll diff is: {:?}", scroll_diff);
                 }
+
+
+                for button in [MouseButton::Left, MouseButton::Right, MouseButton::Middle] {
+                    if input.mouse_pressed(button) {
+                        log::info!("The {:?} mouse button was pressed", button);
+                    }
+
+                    if input.mouse_held(button) {
+                        log::info!("The {:?} mouse button is being held", button);
+                    }
+
+                    if input.mouse_released(button) {
+                        log::info!("The {:?} mouse button was released", button);
+                    }
+                }
+
 
                 // You are expected to control your own timing within this block.
                 // Usually via rendering with vsync.

--- a/src/current_input.rs
+++ b/src/current_input.rs
@@ -105,18 +105,18 @@ impl CurrentInput {
                 button,
                 ..
             } => {
-                let button = mouse_button_to_int(button);
-                self.mouse_held[button] = true;
-                self.mouse_actions.push(MouseAction::Pressed(button));
+                let button_usize = mouse_button_to_int(button);
+                self.mouse_held[button_usize] = true;
+                self.mouse_actions.push(MouseAction::Pressed(*button));
             }
             WindowEvent::MouseInput {
                 state: ElementState::Released,
                 button,
                 ..
             } => {
-                let button = mouse_button_to_int(button);
-                self.mouse_held[button] = false;
-                self.mouse_actions.push(MouseAction::Released(button));
+                let button_usize = mouse_button_to_int(button);
+                self.mouse_held[button_usize] = false;
+                self.mouse_actions.push(MouseAction::Released(*button));
             }
             WindowEvent::MouseWheel { delta, .. } => {
                 // I just took this from three-rs, no idea why this magic number was chosen ¯\_(ツ)_/¯
@@ -163,17 +163,17 @@ pub enum ScanCodeAction {
 
 #[derive(Clone)]
 pub enum MouseAction {
-    Pressed(usize),
-    Released(usize),
+    Pressed(MouseButton),
+    Released(MouseButton),
 }
 
-fn mouse_button_to_int(button: &MouseButton) -> usize {
+pub fn mouse_button_to_int(button: &MouseButton) -> usize {
     match button {
         MouseButton::Left => 0,
         MouseButton::Right => 1,
         MouseButton::Middle => 2,
         MouseButton::Back => 3,
-        MouseButton::Forward => 3,
-        MouseButton::Other(byte) => *byte as usize,
+        MouseButton::Forward => 4,
+        MouseButton::Other(byte) => 5 + *byte as usize,
     }
 }

--- a/src/winit_input_helper.rs
+++ b/src/winit_input_helper.rs
@@ -1,11 +1,12 @@
 use winit::dpi::PhysicalSize;
-use winit::event::{DeviceEvent, Event, WindowEvent};
+use winit::event::{DeviceEvent, Event, MouseButton, WindowEvent};
 use winit::keyboard::{Key, KeyCode, PhysicalKey};
 
-use crate::current_input::{CurrentInput, KeyAction, MouseAction, ScanCodeAction, TextChar};
+use crate::current_input::{
+    mouse_button_to_int, CurrentInput, KeyAction, MouseAction, ScanCodeAction, TextChar,
+};
 use std::{path::PathBuf, time::Duration};
 use web_time::Instant;
-
 /// The main struct of the API.
 ///
 /// Create with `WinitInputHelper::new`.
@@ -304,17 +305,11 @@ impl WinitInputHelper {
 
     /// Returns true when the specified mouse button goes from "not pressed" to "pressed".
     /// Otherwise returns false.
-    ///
-    /// Left   => 0
-    /// Right  => 1
-    /// Middle => 2
-    /// Other  => 3..255
-    pub fn mouse_pressed(&self, check_mouse_button: usize) -> bool {
-        // TODO: Take MouseButton instead of usize
+    pub fn mouse_pressed(&self, mouse_button: MouseButton) -> bool {
         if let Some(current) = &self.current {
             for action in &current.mouse_actions {
                 if let MouseAction::Pressed(key_code) = *action {
-                    if key_code == check_mouse_button {
+                    if key_code == mouse_button {
                         return true;
                     }
                 }
@@ -325,17 +320,11 @@ impl WinitInputHelper {
 
     /// Returns true when the specified mouse button goes from "pressed" to "not pressed".
     /// Otherwise returns false.
-    ///
-    /// Left   => 0
-    /// Right  => 1
-    /// Middle => 2
-    /// Other  => 3..255
-    pub fn mouse_released(&self, check_mouse_button: usize) -> bool {
-        // TODO: Take MouseButton instead of usize
+    pub fn mouse_released(&self, mouse_button: MouseButton) -> bool {
         if let Some(current) = &self.current {
             for action in &current.mouse_actions {
                 if let MouseAction::Released(key_code) = *action {
-                    if key_code == check_mouse_button {
+                    if key_code == mouse_button {
                         return true;
                     }
                 }
@@ -346,15 +335,9 @@ impl WinitInputHelper {
 
     /// Returns true while the specified mouse button remains "pressed".
     /// Otherwise returns false.
-    ///
-    /// Left   => 0
-    /// Right  => 1
-    /// Middle => 2
-    /// Other  => 3..255
-    pub fn mouse_held(&self, mouse_button: usize) -> bool {
-        // TODO: Take MouseButton instead of usize
+    pub fn mouse_held(&self, mouse_button: MouseButton) -> bool {
         match &self.current {
-            Some(current) => current.mouse_held[mouse_button],
+            Some(current) => current.mouse_held[mouse_button_to_int(&mouse_button)],
             None => false,
         }
     }


### PR DESCRIPTION
I was wondering why the mouse helpers (`mouse_pressed`/`mouse_released`/`mouse_held`) were using a usize in the signature instead of winit `MouseButton` enum, which I found annoying and saw a todo for it so I decided to make a PR for it.

These three functions now use the `winit::event::MouseButton` enum instead of a usize as parameter. Internally, `mouse_button_to_int` was made public (but not exported) since I needed it in `mouse_held` and `MouseAction` now also uses the `MouseButton` enum instead of a usize. 

It should be noted that this is a **breaking change** though, but it makes the api much nicer to use imo.

Also in `mouse_button_to_int` I fixed the uint associated with `Forward` that was the same as `Back`. For `Other` I padded it by `4` to make sure it would not overlap with existing mapping. I don't have a mouse with extra button recognized by winit and their doc doesn't specify where the u16 starts afaik, so I decided to be extra careful, but if you have contrary information we can revert it.