### PR TITLE
Fix WinitInputHelper::text

### DIFF
--- a/src/current_input.rs
+++ b/src/current_input.rs
@@ -1,17 +1,5 @@
 use winit::event::{DeviceEvent, ElementState, MouseButton, MouseScrollDelta, WindowEvent};
-use winit::keyboard::{Key, NamedKey, PhysicalKey};
-
-/// Stores a character or a backspace.
-///
-/// TODO: Either:
-///  *   remove this struct and just use backspace character instead
-///  *   move keypresses like Home, End, Left, Right, Up, Down, Return to this enum
-///  (advantage of using this struct is it retains sub-frame keypress ordering)
-#[derive(Clone)]
-pub enum TextChar {
-    Char(char),
-    Back,
-}
+use winit::keyboard::{Key, PhysicalKey};
 
 #[derive(Clone)]
 pub struct CurrentInput {
@@ -26,7 +14,7 @@ pub struct CurrentInput {
     pub mouse_diff: Option<(f32, f32)>,
     pub y_scroll_diff: f32,
     pub x_scroll_diff: f32,
-    pub text: Vec<TextChar>,
+    pub text: Vec<Key>,
 }
 
 impl CurrentInput {
@@ -71,9 +59,7 @@ impl CurrentInput {
                     self.key_held.push(logical_key.clone());
                     self.key_actions
                         .push(KeyAction::PressedOs(logical_key.clone()));
-                    if let Key::Named(NamedKey::Backspace) = logical_key {
-                        self.text.push(TextChar::Back);
-                    }
+                    self.text.push(logical_key.clone());
 
                     let physical_key = &event.physical_key;
                     if !self.scancode_held.contains(physical_key) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,4 +2,3 @@ mod current_input;
 mod winit_input_helper;
 
 pub use crate::winit_input_helper::WinitInputHelper;
-pub use current_input::TextChar;

--- a/src/winit_input_helper.rs
+++ b/src/winit_input_helper.rs
@@ -3,7 +3,7 @@ use winit::event::{DeviceEvent, Event, MouseButton, WindowEvent};
 use winit::keyboard::{Key, KeyCode, PhysicalKey};
 
 use crate::current_input::{
-    mouse_button_to_int, CurrentInput, KeyAction, MouseAction, ScanCodeAction, TextChar,
+    mouse_button_to_int, CurrentInput, KeyAction, MouseAction, ScanCodeAction,
 };
 use std::{path::PathBuf, time::Duration};
 use web_time::Instant;
@@ -390,11 +390,11 @@ impl WinitInputHelper {
     }
 
     /// Returns the characters pressed during the last step.
-    /// The earlier the character was pressed, the lower the index in the Vec.
-    pub fn text(&self) -> Vec<TextChar> {
+    /// The characters are in the order they were pressed.
+    pub fn text(&self) -> &[Key] {
         match &self.current {
-            Some(current) => current.text.clone(),
-            None => vec![],
+            Some(current) => &current.text,
+            None => &[],
         }
     }
 


### PR DESCRIPTION
**Breaking change**

Closes https://github.com/rukai/winit_input_helper/issues/47

This API was both broken, as raised by #47, and a half-implemented work around of an ancient winit API.

This PR:
* fixes `.text()` so that it actually returns values when keypresses occur
* Removes the `TextChar` enum, instead we return a winit https://docs.rs/winit/latest/winit/keyboard/enum.Key.html