### PR TITLE
Update to winit 0.30 without wrapping winit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 **/*.rs.bk
+.idea

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,9 +20,9 @@ checksum = "c71b1793ee61086797f5c80b6efa2b8ffa6d5dd703f118545808a7f2e27f7046"
 
 [[package]]
 name = "ahash"
-version = "0.8.6"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "getrandom",
@@ -42,12 +42,12 @@ dependencies = [
 
 [[package]]
 name = "android-activity"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39b801912a977c3fd52d80511fe1c0c8480c6f957f21ae2ce1b92ffe970cf4b9"
+checksum = "ef6978589202a00cd7e118380c448a08b6ed394c3a8df3a430d0898e3a42d046"
 dependencies = [
  "android-properties",
- "bitflags 2.4.1",
+ "bitflags 2.6.0",
  "cc",
  "cesu8",
  "jni",
@@ -169,26 +169,16 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
-
-[[package]]
-name = "block-sys"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dd7cf50912cddc06dc5ea7c08c5e81c1b2c842a70d19def1848d54c586fed92"
-dependencies = [
- "objc-sys",
-]
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "block2"
-version = "0.3.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b55663a85f33501257357e6421bb33e769d5c9ffb5ba0921c975a123e35e68"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
 dependencies = [
- "block-sys",
  "objc2",
 ]
 
@@ -218,11 +208,11 @@ checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "calloop"
-version = "0.12.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b50b5a44d59a98c55a9eeb518f39bf7499ba19fd98ee7d22618687f3f10adbf"
+checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.6.0",
  "log",
  "polling",
  "rustix",
@@ -232,9 +222,9 @@ dependencies = [
 
 [[package]]
 name = "calloop-wayland-source"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0ea9b9476c7fad82841a8dbb380e2eae480c21910feba80725b46931ed8f02"
+checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
 dependencies = [
  "calloop",
  "rustix",
@@ -278,9 +268,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "colorchoice"
@@ -408,6 +398,12 @@ name = "downcast-rs"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
+
+[[package]]
+name = "dpi"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f25c0e292a7ca6d6498557ff1df68f32c99850012b6ea401cf8daf771f22ff53"
 
 [[package]]
 name = "env_filter"
@@ -547,17 +543,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
-name = "icrate"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d3aaff8a54577104bafdf686ff18565c3b6903ca5782a2026ef06e2c7aa319"
-dependencies = [
- "block2",
- "dispatch",
- "objc2",
-]
-
-[[package]]
 name = "id-arena"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -657,9 +642,9 @@ version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3af92c55d7d839293953fcd0fda5ecfe93297cfde6ffbdec13b41d99c0ba6607"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.6.0",
  "libc",
- "redox_syscall 0.4.1",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -690,21 +675,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "memoffset"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "ndk"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
+checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.6.0",
  "jni-sys",
  "log",
  "ndk-sys",
@@ -721,9 +697,9 @@ checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "ndk-sys"
-version = "0.5.0+25.2.9519653"
+version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
+checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys",
 ]
@@ -737,7 +713,6 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
- "memoffset",
 ]
 
 [[package]]
@@ -763,25 +738,206 @@ dependencies = [
 
 [[package]]
 name = "objc-sys"
-version = "0.3.2"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c71324e4180d0899963fc83d9d241ac39e699609fc1025a850aadac8257459"
+checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
 
 [[package]]
 name = "objc2"
-version = "0.4.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "559c5a40fdd30eb5e344fbceacf7595a81e242529fb4e21cf5f43fb4f11ff98d"
+checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
 dependencies = [
  "objc-sys",
  "objc2-encode",
 ]
 
 [[package]]
-name = "objc2-encode"
-version = "3.0.0"
+name = "objc2-app-kit"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d079845b37af429bfe5dfa76e6d087d788031045b25cfc6fd898486fd9847666"
+checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-data",
+ "objc2-core-image",
+ "objc2-foundation",
+ "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2",
+ "objc2",
+ "objc2-core-location",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-contacts"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-foundation",
+ "objc2-metal",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-contacts",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7891e71393cd1f227313c9379a26a584ff3d7e6e7159e988851f0934c993f0f8"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2",
+ "dispatch",
+ "libc",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-link-presentation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+ "objc2-metal",
+]
+
+[[package]]
+name = "objc2-symbols"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2",
+ "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-foundation",
+ "objc2-link-presentation",
+ "objc2-quartz-core",
+ "objc2-symbols",
+ "objc2-uniform-type-identifiers",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-uniform-type-identifiers"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2",
+ "objc2",
+ "objc2-core-location",
+ "objc2-foundation",
+]
 
 [[package]]
 name = "once_cell"
@@ -818,6 +974,26 @@ name = "pico-args"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
+name = "pin-project"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.43",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -866,9 +1042,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.30.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
+checksum = "6f24d770aeca0eacb81ac29dfbc55ebcc09312fdd1f8bbecdc7e4a84e000e3b4"
 dependencies = [
  "memchr",
 ]
@@ -887,15 +1063,6 @@ name = "raw-window-handle"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42a9830a0e1b9fb145ebb365b8bc4ccd75f290f98c0247deafbbe2c75cefb544"
-
-[[package]]
-name = "redox_syscall"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
-dependencies = [
- "bitflags 1.3.2",
-]
 
 [[package]]
 name = "redox_syscall"
@@ -954,7 +1121,7 @@ version = "0.38.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -990,9 +1157,9 @@ checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "sctk-adwaita"
-version = "0.8.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b2eaf3a5b264a521b988b2e73042e742df700c4f962cde845d1541adb46550"
+checksum = "b6277f0217056f77f1d8f49f2950ac6c278c0d607c45f5ee99328d792ede24ec"
 dependencies = [
  "ab_glyph",
  "log",
@@ -1049,11 +1216,11 @@ checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 
 [[package]]
 name = "smithay-client-toolkit"
-version = "0.18.0"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60e3d9941fa3bacf7c2bf4b065304faa14164151254cd16ce1b1bc8fc381600f"
+checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.6.0",
  "calloop",
  "calloop-wayland-source",
  "cursor-icon",
@@ -1123,7 +1290,7 @@ checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall 0.4.1",
+ "redox_syscall",
  "rustix",
  "windows-sys 0.52.0",
 ]
@@ -1438,13 +1605,13 @@ checksum = "449167e2832691a1bff24cde28d2804e90e09586a448c8e76984792c44334a6b"
 
 [[package]]
 name = "wayland-backend"
-version = "0.3.2"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19152ddd73f45f024ed4534d9ca2594e0ef252c1847695255dae47f34df9fbe4"
+checksum = "f90e11ce2ca99c97b940ee83edbae9da2d56a08f9ea8158550fd77fa31722993"
 dependencies = [
  "cc",
  "downcast-rs",
- "nix",
+ "rustix",
  "scoped-tls",
  "smallvec",
  "wayland-sys",
@@ -1452,12 +1619,12 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.31.1"
+version = "0.31.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ca7d52347346f5473bf2f56705f360e8440873052e575e55890c4fa57843ed3"
+checksum = "7e321577a0a165911bdcfb39cf029302479d7527b517ee58ab0f6ad09edf0943"
 dependencies = [
- "bitflags 2.4.1",
- "nix",
+ "bitflags 2.6.0",
+ "rustix",
  "wayland-backend",
  "wayland-scanner",
 ]
@@ -1468,7 +1635,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.6.0",
  "cursor-icon",
  "wayland-backend",
 ]
@@ -1486,11 +1653,11 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.31.0"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e253d7107ba913923dc253967f35e8561a3c65f914543e46843c88ddd729e21c"
+checksum = "62989625a776e827cc0f15d41444a3cea5205b963c3a25be48ae1b52d6b4daaa"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.6.0",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -1498,11 +1665,11 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-plasma"
-version = "0.2.0"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23803551115ff9ea9bce586860c5c5a971e360825a0309264102a9495a5ff479"
+checksum = "f79f2d57c7fcc6ab4d602adba364bf59a5c24de57bd194486bf9b8360e06bfc4"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.6.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -1511,11 +1678,11 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-wlr"
-version = "0.2.0"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1f61b76b6c2d8742e10f9ba5c3737f6530b4c243132c2a2ccc8aa96fe25cd6"
+checksum = "fd993de54a40a40fbe5601d9f1fbcaef0aebcc5fda447d7dc8f6dcbaae4f8953"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.6.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -1524,9 +1691,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.0"
+version = "0.31.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb8e28403665c9f9513202b7e1ed71ec56fde5c107816843fb14057910b2c09c"
+checksum = "d7b56f89937f1cf2ee1f1259cf2936a17a1f45d8f0aa1019fae6d470d304cfa6"
 dependencies = [
  "proc-macro2",
  "quick-xml",
@@ -1535,9 +1702,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-sys"
-version = "0.31.1"
+version = "0.31.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15a0c8eaff5216d07f226cb7a549159267f3467b289d9a2e52fd3ef5aae2b7af"
+checksum = "43676fe2daf68754ecf1d72026e4e6c15483198b5d24e888b74d3f22f887a148"
 dependencies = [
  "dlib",
  "log",
@@ -1550,16 +1717,6 @@ name = "web-sys"
 version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "web-time"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa30049b1c872b72c89866d458eae9f20380ab280ffd1b1e18df2d3e2d98cfe0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1806,37 +1963,41 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winit"
-version = "0.29.7"
+version = "0.30.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd430cd4560ee9c48885a4ef473b609a56796e37b1e18222abee146143f7457"
+checksum = "0be9e76a1f1077e04a411f0b989cbd3c93339e1771cb41e71ac4aee95bfd2c67"
 dependencies = [
  "ahash",
  "android-activity",
  "atomic-waker",
- "bitflags 2.4.1",
+ "bitflags 2.6.0",
+ "block2",
  "bytemuck",
  "calloop",
  "cfg_aliases",
+ "concurrent-queue",
  "core-foundation",
  "core-graphics",
  "cursor-icon",
- "icrate",
+ "dpi",
  "js-sys",
  "libc",
- "log",
  "memmap2",
  "ndk",
- "ndk-sys",
  "objc2",
- "once_cell",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "objc2-ui-kit",
  "orbclient",
  "percent-encoding",
+ "pin-project",
  "raw-window-handle",
- "redox_syscall 0.3.5",
+ "redox_syscall",
  "rustix",
  "sctk-adwaita",
  "smithay-client-toolkit",
  "smol_str",
+ "tracing",
  "unicode-segmentation",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -1845,8 +2006,8 @@ dependencies = [
  "wayland-protocols",
  "wayland-protocols-plasma",
  "web-sys",
- "web-time 0.2.4",
- "windows-sys 0.48.0",
+ "web-time",
+ "windows-sys 0.52.0",
  "x11-dl",
  "x11rb",
  "xkbcommon-dl",
@@ -1860,7 +2021,7 @@ dependencies = [
  "console_log",
  "env_logger",
  "log",
- "web-time 1.0.0",
+ "web-time",
  "winit",
 ]
 
@@ -1913,11 +2074,11 @@ checksum = "6a0ccd7b4a5345edfcd0c3535718a4e9ff7798ffc536bb5b5a0e26ff84732911"
 
 [[package]]
 name = "xkbcommon-dl"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6924668544c48c0133152e7eec86d644a056ca3d09275eb8d5cdb9855f9d8699"
+checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.6.0",
  "dlib",
  "log",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,11 @@ keywords = ["winit", "input", "helper", "state", "cache"]
 categories = ["game-engines", "os", "gui"]
 
 [dependencies]
-winit = { version = "0.29", default-features = false }
+winit = { version = "0.30", default-features = false }
 web-time = "1.0"
 
 [dev-dependencies]
-winit = { version = "0.29" }
+winit = { version = "0.30" }
 log = "0.4"
 console_log = "1.0"
 console_error_panic_hook = "0.1"

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -1,123 +1,159 @@
 //! A complex example demonstrating use of every API feature, runs on both desktop and web.
 //! To run on desktop: `cargo run --example example`
 //! To run on web: `cargo run-wasm --example example`
-use winit::event::MouseButton;
-use winit::event_loop::EventLoop;
+use winit::application::ApplicationHandler;
+use winit::event::{DeviceEvent, DeviceId, MouseButton, StartCause, WindowEvent};
+use winit::event_loop::{ActiveEventLoop, EventLoop};
 use winit::keyboard::{Key, KeyCode};
+use winit::window::{Window, WindowId};
 use winit_input_helper::WinitInputHelper;
 
 fn main() {
     platform::init();
 
-    let mut input = WinitInputHelper::new();
-
     let event_loop = EventLoop::new().unwrap();
 
-    let _window = platform::create_window(&event_loop);
-
     event_loop
-        .run(move |event, elwt| {
-            // Pass every event to the WinitInputHelper.
-            // It will return true when the last event has been processed and it is time to run your application logic.
-            if input.update(&event) {
-                if input.key_released(KeyCode::KeyQ) || input.close_requested() || input.destroyed()
-                {
-                    log::info!("The application was requsted to close or the 'Q' key was pressed, quiting the application");
-                    elwt.exit();
-                    return;
-                }
-
-                // If you are taking input for a game or similar you should use physical keys.
-
-                if input.key_pressed(KeyCode::KeyW) {
-                    log::info!("The 'W' key (US layout) was pressed on the keyboard");
-                }
-
-                if input.key_pressed_os(KeyCode::KeyE) {
-                    log::info!(
-                        "The 'E' key (US layout) was pressed on the keyboard (Os Repeating)"
-                    );
-                }
-
-                if input.key_held(KeyCode::KeyR) {
-                    log::info!("The 'R' key (US layout) is held");
-                }
-
-                // Logical keys are usually used for text input and rarely make sense in the way they are presented in this API.
-
-                if input.key_pressed_logical(Key::Character("a")) {
-                    log::info!("'a' was input by the keyboard");
-                }
-
-                if input.key_pressed_logical(Key::Character("A")) {
-                    log::info!("'A' was input by the keyboard (detected seperately to 'a')");
-                }
-
-                if input.key_pressed_os_logical(Key::Character("s")) {
-                    log::info!("'s' was input by the keyboard (OS repeating)");
-                }
-
-                if input.key_held_logical(Key::Character("d")) {
-                    log::info!("`d` input is held on the keyboard");
-                }
-
-                // query the change in cursor this update
-                let cursor_diff = input.cursor_diff();
-                if cursor_diff != (0.0, 0.0) {
-                    log::info!("The cursor diff is: {:?}", cursor_diff);
-                    log::info!("The cursor position is: {:?}", input.cursor());
-                }
-
-                // query the change in mouse this update (useful for first person camera controls)
-                let mouse_diff = input.mouse_diff();
-                if mouse_diff != (0.0, 0.0) {
-                    log::info!("The mouse diff is: {:?}", mouse_diff);
-                }
-
-                let scroll_diff = input.scroll_diff();
-                if scroll_diff != (0.0, 0.0) {
-                    log::info!("The scroll diff is: {:?}", scroll_diff);
-                }
-
-
-                for button in [MouseButton::Left, MouseButton::Right, MouseButton::Middle] {
-                    if input.mouse_pressed(button) {
-                        log::info!("The {:?} mouse button was pressed", button);
-                    }
-
-                    if input.mouse_held(button) {
-                        log::info!("The {:?} mouse button is being held", button);
-                    }
-
-                    if input.mouse_released(button) {
-                        log::info!("The {:?} mouse button was released", button);
-                    }
-                }
-
-
-                // You are expected to control your own timing within this block.
-                // Usually via rendering with vsync.
-                // render();
-            }
+        .run_app(&mut App {
+            input: WinitInputHelper::new(),
+            _window: None,
         })
         .unwrap();
 }
 
+struct App {
+    input: WinitInputHelper,
+    _window: Option<Window>,
+}
+
+impl ApplicationHandler for App {
+    fn new_events(&mut self, _event_loop: &ActiveEventLoop, _cause: StartCause) {
+        self.input.step();
+    }
+
+    fn resumed(&mut self, _event_loop: &ActiveEventLoop) {
+        if self._window.is_none() {
+            let window = platform::create_window(&_event_loop);
+            self._window = Some(window);
+        }
+    }
+
+    fn window_event(
+        &mut self,
+        _event_loop: &ActiveEventLoop,
+        _window_id: WindowId,
+        event: WindowEvent,
+    ) {
+        self.input.process_window_event(&event);
+    }
+
+    fn device_event(
+        &mut self,
+        _event_loop: &ActiveEventLoop,
+        _device_id: DeviceId,
+        event: DeviceEvent,
+    ) {
+        self.input.process_device_event(&event);
+    }
+
+    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
+        self.input.end_step();
+
+        if self.input.key_released(KeyCode::KeyQ)
+            || self.input.close_requested()
+            || self.input.destroyed()
+        {
+            log::info!("The application was requsted to close or the 'Q' key was pressed, quiting the application");
+            event_loop.exit();
+            // If you don't drop window, the app won't quit before any other window event.
+            // https://github.com/rust-windowing/winit/issues/3673
+            self._window = None;
+            return;
+        }
+
+        // If you are taking input for a game or similar you should use physical keys.
+
+        if self.input.key_pressed(KeyCode::KeyW) {
+            log::info!("The 'W' key (US layout) was pressed on the keyboard");
+        }
+
+        if self.input.key_pressed_os(KeyCode::KeyE) {
+            log::info!("The 'E' key (US layout) was pressed on the keyboard (Os Repeating)");
+        }
+
+        if self.input.key_held(KeyCode::KeyR) {
+            log::info!("The 'R' key (US layout) is held");
+        }
+
+        // Logical keys are usually used for text input and rarely make sense in the way they are presented in this API.
+
+        if self.input.key_pressed_logical(Key::Character("a")) {
+            log::info!("'a' was input by the keyboard");
+        }
+
+        if self.input.key_pressed_logical(Key::Character("A")) {
+            log::info!("'A' was input by the keyboard (detected seperately to 'a')");
+        }
+
+        if self.input.key_pressed_os_logical(Key::Character("s")) {
+            log::info!("'s' was input by the keyboard (OS repeating)");
+        }
+
+        if self.input.key_held_logical(Key::Character("d")) {
+            log::info!("`d` input is held on the keyboard");
+        }
+
+        // query the change in cursor this update
+        let cursor_diff = self.input.cursor_diff();
+        if cursor_diff != (0.0, 0.0) {
+            log::info!("The cursor diff is: {:?}", cursor_diff);
+            log::info!("The cursor position is: {:?}", self.input.cursor());
+        }
+
+        // query the change in mouse this update (useful for first person camera controls)
+        let mouse_diff = self.input.mouse_diff();
+        if mouse_diff != (0.0, 0.0) {
+            log::info!("The mouse diff is: {:?}", mouse_diff);
+        }
+
+        let scroll_diff = self.input.scroll_diff();
+        if scroll_diff != (0.0, 0.0) {
+            log::info!("The scroll diff is: {:?}", scroll_diff);
+        }
+
+        for button in [MouseButton::Left, MouseButton::Right, MouseButton::Middle] {
+            if self.input.mouse_pressed(button) {
+                log::info!("The {:?} mouse button was pressed", button);
+            }
+
+            if self.input.mouse_held(button) {
+                log::info!("The {:?} mouse button is being held", button);
+            }
+
+            if self.input.mouse_released(button) {
+                log::info!("The {:?} mouse button was released", button);
+            }
+        }
+
+        // You are expected to control your own timing within this block.
+        // Usually via rendering with vsync.
+        // render();
+    }
+}
+
 #[cfg(target_arch = "wasm32")]
 mod platform {
-    use winit::event_loop::EventLoop;
-    use winit::platform::web::WindowBuilderExtWebSys;
+    use winit::event_loop::{ActiveEventLoop, EventLoop};
+    use winit::platform::web::WindowAttributesExtWebSys;
     use winit::platform::web::WindowExtWebSys;
-    use winit::window::{Window, WindowBuilder};
+    use winit::window::{Window, WindowAttributes};
 
-    pub fn create_window(event_loop: &EventLoop<()>) -> Window {
-        let window = WindowBuilder::new()
-            .with_append(true)
-            .build(event_loop)
-            .unwrap();
+    pub fn create_window(event_loop: &ActiveEventLoop) -> Window {
+        let window_attrs = Window::default_attributes().with_append(true);
+        let window = event_loop.create_window(window_attrs).unwrap();
 
         // Set a background color for the canvas to make it easier to tell the where the canvas is for debugging purposes.
-        let canvas = window.canvas().unwrap();
+        let canvas = window.cavas().unwrap();
         canvas.style().set_css_text(
             "display: block; background-color: crimson; margin: auto; width: 50%; aspect-ratio: 4 / 2;",
         );
@@ -132,11 +168,13 @@ mod platform {
 
 #[cfg(not(target_arch = "wasm32"))]
 mod platform {
-    use winit::event_loop::EventLoop;
-    use winit::window::{Window, WindowBuilder};
+    use winit::event_loop::ActiveEventLoop;
+    use winit::window::Window;
 
-    pub fn create_window(event_loop: &EventLoop<()>) -> Window {
-        WindowBuilder::new().build(event_loop).unwrap()
+    pub fn create_window(event_loop: &ActiveEventLoop) -> Window {
+        event_loop
+            .create_window(Window::default_attributes())
+            .unwrap()
     }
 
     pub fn init() {

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,37 +1,78 @@
 //! The simplest example, supporting only desktop applications.
-
-use winit::event_loop::EventLoop;
+use winit::application::ApplicationHandler;
+use winit::event::{DeviceEvent, DeviceId, StartCause, WindowEvent};
+use winit::event_loop::{ActiveEventLoop, EventLoop};
 use winit::keyboard::KeyCode;
-use winit::window::WindowBuilder;
+use winit::window::{Window, WindowId};
 use winit_input_helper::WinitInputHelper;
 
 fn main() {
-    let mut input = WinitInputHelper::new();
-
     let event_loop = EventLoop::new().unwrap();
-    let _window = WindowBuilder::new().build(&event_loop).unwrap();
 
     event_loop
-        .run(move |event, elwt| {
-            // Pass every event to the WinitInputHelper.
-            // It will return true when the last event has been processed and it is time to run your application logic.
-            if input.update(&event) {
-                if input.key_released(KeyCode::KeyQ) || input.close_requested() || input.destroyed()
-                {
-                    println!("The application was requsted to close or the 'Q' key was pressed, quiting the application");
-                    elwt.exit();
-                    return;
-                }
-
-                if input.key_pressed(KeyCode::KeyW) {
-                    println!("The 'W' key (US layout) was pressed on the keyboard");
-                }
-
-
-                // You are expected to control your own timing within this block.
-                // Usually via rendering with vsync.
-                // render();
-            }
+        .run_app(&mut App {
+            input: WinitInputHelper::new(),
+            _window: None,
         })
         .unwrap();
+}
+
+struct App {
+    input: WinitInputHelper,
+    _window: Option<Window>,
+}
+
+impl ApplicationHandler for App {
+    fn new_events(&mut self, _event_loop: &ActiveEventLoop, _cause: StartCause) {
+        self.input.step();
+    }
+
+    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+        if self._window.is_none() {
+            let window = event_loop.create_window(Default::default()).unwrap();
+            self._window = Some(window);
+        }
+    }
+
+    fn window_event(
+        &mut self,
+        _event_loop: &ActiveEventLoop,
+        _window_id: WindowId,
+        event: WindowEvent,
+    ) {
+        self.input.process_window_event(&event);
+    }
+
+    fn device_event(
+        &mut self,
+        _event_loop: &ActiveEventLoop,
+        _device_id: DeviceId,
+        event: DeviceEvent,
+    ) {
+        self.input.process_device_event(&event);
+    }
+
+    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
+        self.input.end_step();
+
+        if self.input.key_released(KeyCode::KeyQ)
+            || self.input.close_requested()
+            || self.input.destroyed()
+        {
+            println!("The application was requsted to close or the 'Q' key was pressed, quiting the application");
+            event_loop.exit();
+            // If you don't drop window, the app won't quit before any other window event.
+            // https://github.com/rust-windowing/winit/issues/3673
+            self._window = None;
+            return;
+        }
+
+        if self.input.key_pressed(KeyCode::KeyW) {
+            println!("The 'W' key (US layout) was pressed on the keyboard");
+        }
+
+        // You are expected to control your own timing within this block.
+        // Usually via rendering with vsync.
+        // render();
+    }
 }

--- a/src/winit_input_helper.rs
+++ b/src/winit_input_helper.rs
@@ -1,5 +1,5 @@
 use winit::dpi::PhysicalSize;
-use winit::event::{DeviceEvent, Event, MouseButton, WindowEvent};
+use winit::event::{DeviceEvent, MouseButton, WindowEvent};
 use winit::keyboard::{Key, KeyCode, PhysicalKey};
 
 use crate::current_input::{
@@ -56,40 +56,12 @@ impl WinitInputHelper {
         }
     }
 
-    /// Pass every winit event to this function and run your application logic when it returns true.
-    ///
-    /// The following winit events are handled:
-    /// *   `Event::NewEvents` clears all internal state.
-    /// *   `Event::MainEventsCleared` causes this function to return true, signifying a "step" has completed.
-    /// *   `Event::WindowEvent` updates internal state, this will affect the result of accessor methods immediately.
-    /// *   `Event::DeviceEvent` updates value of `mouse_diff()`
-    pub fn update<T>(&mut self, event: &Event<T>) -> bool {
-        match &event {
-            Event::NewEvents(_) => {
-                self.step();
-                false
-            }
-            Event::WindowEvent { event, .. } => {
-                self.process_window_event(event);
-                false
-            }
-            Event::DeviceEvent { event, .. } => {
-                self.process_device_event(event);
-                false
-            }
-            Event::AboutToWait => {
-                self.end_step();
-                true
-            }
-            _ => false,
-        }
-    }
-
     /// Pass a slice containing every winit event that occured within the step to this function.
     /// Ensure this method is only called once per application main loop.
     /// Ensure every event since the last `WinitInputHelper::step_with_window_events` call is included in the `events` argument.
     ///
-    /// `WinitInputHelper::Update` is easier to use.
+    /// Controlling usage with
+    /// `WinitInputHelper::step`, `window_event`, `device_event` and `end_step` is easier.
     /// But this method is useful when your application logic steps dont line up with winit's event loop.
     /// e.g. you have a seperate thread for application logic using WinitInputHelper that constantly
     /// runs regardless of winit's event loop and you need to send events to it directly.
@@ -101,7 +73,7 @@ impl WinitInputHelper {
         self.end_step();
     }
 
-    fn step(&mut self) {
+    pub fn step(&mut self) {
         self.dropped_file = None;
         self.window_resized = None;
         self.scale_factor_changed = None;
@@ -114,7 +86,7 @@ impl WinitInputHelper {
         }
     }
 
-    fn process_window_event(&mut self, event: &WindowEvent) {
+    pub fn process_window_event(&mut self, event: &WindowEvent) {
         match event {
             WindowEvent::CloseRequested => self.close_requested = true,
             WindowEvent::Destroyed => self.destroyed = true,
@@ -140,13 +112,13 @@ impl WinitInputHelper {
         }
     }
 
-    fn process_device_event(&mut self, event: &DeviceEvent) {
+    pub fn process_device_event(&mut self, event: &DeviceEvent) {
         if let Some(ref mut current) = self.current {
             current.handle_device_event(event);
         }
     }
 
-    fn end_step(&mut self) {
+    pub fn end_step(&mut self) {
         self.step_duration = self.step_start.map(|start| start.elapsed());
         self.step_start = Some(Instant::now());
     }


### PR DESCRIPTION
Here is an alternative to #61.

I didn't want the winit_input_helper to be wrapped as winit app.

If this isn't good, this can be closed.