### PR TITLE
Pre-built cargo hack binary in CI + bump MSRV to match winit

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -35,7 +35,9 @@ jobs:
         # Otherwise only the last build to finish would get saved to the cache.
         key: ${{ matrix.name }}
     - name: Install cargo-hack
-      run: cargo install cargo-hack --version 0.6.22
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-hack@0.6.22
     - name: Check `cargo fmt` was run
       run: cargo fmt --all -- --check
     # If your library does not support running under every possible combination of features,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.75"
+channel = "1.80"
 components = [ "rustfmt", "clippy" ]


### PR DESCRIPTION
Confused why CI hasnt run for any of the open PRs, nudging the repo, to see if it triggers CI.